### PR TITLE
Add the `disconnect/1`

### DIFF
--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
 %{"earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.11.5", "0dc51cb84f8312162a2313d6c71573a9afa332333d8a332bb12540861b9834db", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
   "gproc": {:hex, :gproc, "0.5.0", "2df2d886f8f8a7b81a4b04aa17972b5965bbc5bf0100ea6d8e8ac6a0e7389afe", [:rebar], []},
-  "vmq_commons": {:git, "https://github.com/erlio/vmq_commons.git", "63e9a0ed9d2b1c433ee292806e188d3578388d4b", []}}
+  "vmq_commons": {:git, "https://github.com/erlio/vmq_commons.git", "610a83184bf36652e2c72225158301a9c9478c03", []}}


### PR DESCRIPTION
Will disconnect the process from the MQTT broker and stop the process. This will not trigger the `on_disconnect/1` callback, but the `terminate/2` will get called with the shutdown reason being `:normal`.

This can be merged when gen_emqtt get the disconnect function in vmq_commons, which is being worked on in this pull request: https://github.com/erlio/vmq_commons/pull/6
