### PR TITLE
Added retain option to the publish function

### DIFF
--- a/lib/gen_mqtt.ex
+++ b/lib/gen_mqtt.ex
@@ -115,6 +115,7 @@ defmodule GenMQTT do
   # gen_emqtt ----------------------------------------------------------
   @type topic :: [binary] | binary
   @type qos :: 0 | 1 | 2
+  @type retain :: boolean()
 
   @doc """
   Triggered when the client successfully establish a connection to the
@@ -506,13 +507,20 @@ defmodule GenMQTT do
 
   @doc """
   Publish `payload` to `topic` with quality of service set to `qos`
+
+  If `retain` is set to `true` the published message will be retained
+  on the topic, and delivered to new subscribers joining the
+  topic. Only one message per topic can be retained at a time; sending
+  a new retained message will overwrite the old one, regardless of the
+  publisher. `retain` defaults to `false`.
   """
-  @spec publish(pid, topic, payload :: binary, qos) :: :ok
-  def publish(pid, topic, payload, qos) when is_list(topic) do
-    :gen_emqtt.publish(pid, topic, payload, qos)
+  @spec publish(pid, topic, payload :: binary, qos, retain) :: :ok
+  def publish(pid, topic, payload, qos, retain \\ false)
+  def publish(pid, topic, payload, qos, retain) when is_list(topic) do
+    :gen_emqtt.publish(pid, topic, payload, qos, retain)
   end
-  def publish(pid, topic, payload, qos) when is_binary(topic) do
-    publish(pid, [topic], payload, qos)
+  def publish(pid, topic, payload, qos, retain) when is_binary(topic) do
+    publish(pid, [topic], payload, qos, retain)
   end
 
   @doc """

--- a/mix.lock
+++ b/mix.lock
@@ -2,4 +2,4 @@
   "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.11.5", "0dc51cb84f8312162a2313d6c71573a9afa332333d8a332bb12540861b9834db", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
   "gproc": {:hex, :gproc, "0.5.0", "2df2d886f8f8a7b81a4b04aa17972b5965bbc5bf0100ea6d8e8ac6a0e7389afe", [:rebar], []},
-  "vmq_commons": {:git, "https://github.com/erlio/vmq_commons.git", "610a83184bf36652e2c72225158301a9c9478c03", []}}
+  "vmq_commons": {:git, "https://github.com/erlio/vmq_commons.git", "480af9cdc2a8dff3da3a7ee2ecfc4f0527f7b05a", []}}


### PR DESCRIPTION
- `retain` defaults to false, so the API remains intact
- Added a unit test for retained messages
- Updated to a new version of vmq_commons
