### PR TITLE
bugfix: last_will_topic and last_will_msg should be binaries

### DIFF
--- a/lib/gen_mqtt.ex
+++ b/lib/gen_mqtt.ex
@@ -427,7 +427,7 @@ defmodule GenMQTT do
     end
   end
 
-  @cast_to_char_list [:host, :client, :last_will_topic, :last_will_msg]
+  @cast_to_char_list [:host, :client]
   defp normalize_options(opts) do
     Enum.map(opts, fn
       {key, val} when is_binary(val) and key in @cast_to_char_list ->


### PR DESCRIPTION
vmq_commons has bug in the spec:
https://github.com/erlio/vmq_commons/blob/847d92d23ec212430bd8bace097ee91a033a8ff9/src/gen_emqtt.erl#L61
and
https://github.com/erlio/vmq_commons/blob/847d92d23ec212430bd8bace097ee91a033a8ff9/src/gen_emqtt.erl#L62

Actualy, the last_will_topic and last_will_msg should
be binary and converting last_will_topic to charlist will
cause runtime error in vmq_commons.

See:
https://github.com/erlio/vmq_commons/blob/847d92d23ec212430bd8bace097ee91a033a8ff9/src/gen_emqtt.erl#L533
https://github.com/erlio/vmq_commons/blob/847d92d23ec212430bd8bace097ee91a033a8ff9/src/vmq_topic.erl#L80
https://github.com/erlio/vmq_commons/blob/847d92d23ec212430bd8bace097ee91a033a8ff9/include/vmq_types.hrl#L18
https://github.com/erlio/vmq_commons/blob/847d92d23ec212430bd8bace097ee91a033a8ff9/include/vmq_types.hrl#L21