### PR TITLE
bugfix: last_will_topic should be binary

### DIFF
--- a/lib/gen_mqtt.ex
+++ b/lib/gen_mqtt.ex
@@ -427,7 +427,7 @@ defmodule GenMQTT do
     end
   end
 
-  @cast_to_char_list [:host, :client, :last_will_topic, :last_will_msg]
+  @cast_to_char_list [:host, :client, :last_will_msg]
   defp normalize_options(opts) do
     Enum.map(opts, fn
       {key, val} when is_binary(val) and key in @cast_to_char_list ->


### PR DESCRIPTION
Converting last_will_topic to charlist causes runtime error in vmq_commons
here:
https://github.com/erlio/vmq_commons/blob/847d92d23ec212430bd8bace097ee91a033a8ff9/src/vmq_topic.erl#L80