### PR TITLE
fixed typo in moduledoc.

### DIFF
--- a/lib/gen_mqtt.ex
+++ b/lib/gen_mqtt.ex
@@ -1,6 +1,6 @@
 defmodule GenMQTT do
   @moduledoc ~S"""
-  A behaviour module for implementing MMQT client processes.
+  A behaviour module for implementing MQTT client processes.
 
   ## Example
 


### PR DESCRIPTION
I have found and fixed the typo in the very first line of the moduledoc.