### PR TITLE
fix dialyzer warning (Callback info about the gen_emqtt behaviour is …

### DIFF
--- a/lib/gen_mqtt.ex
+++ b/lib/gen_mqtt.ex
@@ -196,7 +196,7 @@ defmodule GenMQTT do
 
   defmacro __using__(_) do
     quote location: :keep do
-      @behaviour :gen_emqtt
+      @behaviour GenMQTT
 
       @doc false
       def init(state) do


### PR DESCRIPTION
…not available)